### PR TITLE
Fix dark mode listener

### DIFF
--- a/src/offline.js
+++ b/src/offline.js
@@ -359,9 +359,14 @@ Runner.prototype = {
     const darkModeMediaQuery =
         window.matchMedia('(prefers-color-scheme: dark)');
     this.isDarkMode = darkModeMediaQuery && darkModeMediaQuery.matches;
-    darkModeMediaQuery.addListener((e) => {
+    const handleDarkModeChange = (e) => {
       this.isDarkMode = e.matches;
-    });
+    };
+    if (darkModeMediaQuery.addEventListener) {
+      darkModeMediaQuery.addEventListener('change', handleDarkModeChange);
+    } else if (darkModeMediaQuery.addListener) {
+      darkModeMediaQuery.addListener(handleDarkModeChange);
+    }
   },
 
   /**


### PR DESCRIPTION
## Summary
- handle `prefers-color-scheme` changes using `addEventListener`

## Testing
- `node --check src/offline.js`


------
https://chatgpt.com/codex/tasks/task_e_683f546741e0832c9e2ceb05fca5705c