### PR TITLE
fix: correct jump velocity property name

### DIFF
--- a/src/offline.js
+++ b/src/offline.js
@@ -1776,7 +1776,7 @@ Trex.config = {
   GRAVITY: 0.6,
   HEIGHT: 47,
   HEIGHT_DUCK: 25,
-  INIITAL_JUMP_VELOCITY: -10,
+  INITIAL_JUMP_VELOCITY: -10,
   INTRO_DURATION: 1500,
   MAX_JUMP_HEIGHT: 30,
   MIN_JUMP_HEIGHT: 30,
@@ -1875,7 +1875,7 @@ Trex.prototype = {
    * @param {number} setting
    */
   setJumpVelocity(setting) {
-    this.config.INIITAL_JUMP_VELOCITY = -setting;
+    this.config.INITIAL_JUMP_VELOCITY = -setting;
     this.config.DROP_VELOCITY = -setting / 2;
   },
 
@@ -2013,7 +2013,7 @@ Trex.prototype = {
     if (!this.jumping) {
       this.update(0, Trex.status.JUMPING);
       // Tweak the jump velocity based on the speed.
-      this.jumpVelocity = this.config.INIITAL_JUMP_VELOCITY - (speed / 10);
+      this.jumpVelocity = this.config.INITIAL_JUMP_VELOCITY - (speed / 10);
       this.jumping = true;
       this.reachedMinHeight = false;
       this.speedDrop = false;


### PR DESCRIPTION
## Summary
- rename the T-Rex config property to `INITIAL_JUMP_VELOCITY`
- update references in `setJumpVelocity` and `startJump`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f312800832cb63a29577692d564